### PR TITLE
Fix issues

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,4 +22,4 @@ jobs:
           poetry-version: 1.4.2
 
       - name: Build and publish
-        run: poetry mkdocs gh-deploy --force
+        run: poetry run mkdocs gh-deploy --force

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ A Jinja2 template processor for interacting with an SQL engine.
 ## Installation
 
 ```bash
-pip install miniset
+pip install mini-set
 ```
 
 ## Basic Usage

--- a/miniset/__init__.py
+++ b/miniset/__init__.py
@@ -3,4 +3,4 @@ import importlib.metadata
 from .jinja_context import JinjaTemplateProcessor  # noqa: F401
 from .types import ParamStyleType  # noqa: F401
 
-__version__ = importlib.metadata.version(__name__)
+__version__ = importlib.metadata.version("mini-set")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "miniset"
+name = "mini-set"
 version = "0.0.0"
 description = "A Jinja2 template processor for interacting with an SQL engine"
 authors = ["Manabu Niseki <manabu.niseki@gmail.com>"]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,5 @@
+from miniset import __version__
+
+
+def test_version():
+    assert isinstance(__version__, str)


### PR DESCRIPTION
- Rename the package to `mini-set` to avoid the following error.
```
HTTP Error 400: The name 'miniset' isn't allowed. See https://pypi.org/help/#project-name for more information. | b"<html>\n <head>\n  <title>400 The name 'miniset' isn't allowed. See https://pypi.org/help/#project-name for more information.\n \n <body>\n  <h1>400 The name 'miniset' isn't allowed. See https://pypi.org/help/#project-name for more information.\n  The server could not comply with the request since it is either malformed or otherwise incorrect.<br/><br/>\nThe name &#x27;miniset&#x27; isn&#x27;t allowed. See https://pypi.org/help/#project-name for more information.\n\n\n \n"
```
- Add `run` prefix to run the command with Poetry
